### PR TITLE
Avoid redundant Superstring sidebar reattachment

### DIFF
--- a/src/epoxy.js
+++ b/src/epoxy.js
@@ -148,8 +148,9 @@ window.addEventListener("pageshow", () => {
         const sidebarContent = sidebarContainer.querySelector('.sidebar') || sidebarContainer;
         const superstringSections = sidebarContainer.querySelectorAll('.superstring');
         const existingSuperstring = superstringSections[superstringSections.length - 1] || null;
+        const superstringHref = getSuperstringSidebarHref();
 
-        console.log('Epoxy: sidebar mutation detected.', {
+        console.debug('Epoxy: sidebar mutation detected.', {
             sidebar,
             sidebarContainer,
             sidebarContent,
@@ -168,8 +169,18 @@ window.addEventListener("pageshow", () => {
                     }
                 });
             }
+            if (superstringHref) {
+                const link = existingSuperstring.querySelector('a[href]');
+                if (link && link.href !== superstringHref) {
+                    console.debug('Epoxy: updating Superstring link href.', {
+                        previousHref: link.href,
+                        nextHref: superstringHref,
+                    });
+                    link.href = superstringHref;
+                }
+            }
             if (sidebarContent.lastElementChild !== existingSuperstring) {
-                console.log('Epoxy: moving Superstring section to end of sidebar.', {
+                console.debug('Epoxy: moving Superstring section to end of sidebar.', {
                     sidebarContent,
                     existingSuperstring,
                 });
@@ -209,7 +220,7 @@ window.addEventListener("pageshow", () => {
                 bodyContainer.appendChild(actionLinks);
                 superstring.appendChild(bodyContainer);
 
-                console.log('Epoxy: adding Superstring section to sidebar.', {
+                console.debug('Epoxy: adding Superstring section to sidebar.', {
                     sidebarContent,
                     superstring,
                 });
@@ -229,13 +240,24 @@ window.addEventListener("pageshow", () => {
                 actionLinks.appendChild(link);
                 superstring.appendChild(actionLinks);
 
-                console.log('Epoxy: adding Superstring section to sidebar.', {
+                console.debug('Epoxy: adding Superstring section to sidebar.', {
                     sidebarContent,
                     superstring,
                 });
                 sidebarContent.appendChild(superstring);
             }
         }
+    }
+
+    function getSuperstringSidebarHref() {
+        // Match URLs for contacts, configurations, or contract items
+        const pathTest = /\/(\d+)\/(contacts|configurations|assets\/92578.+\/records)\/(\d+)/;
+        const match = location.pathname.match(pathTest);
+        if (!match) {
+            return null;
+        }
+        const assetType = /assets\/92578/.test(match[2]) ? 'contract-items' : match[2];
+        return `https://superstring.cascadepc.com/bda/${assetType}/${match[3]}`;
     }
     
     function addSuperstringOrganizationSection(container) {

--- a/src/epoxy.js
+++ b/src/epoxy.js
@@ -138,7 +138,20 @@ window.addEventListener("pageshow", () => {
     }
 
     function addSuperstringSidebarSection(sidebar) {
-        if (location.host != 'cascadepc.itglue.com' || hasSuperstring(sidebar)) {
+        if (location.host != 'cascadepc.itglue.com') {
+            return;
+        }
+
+        const sidebarContainer = sidebar.classList.contains('sidebar-container')
+            ? sidebar
+            : sidebar.closest('.sidebar-container') || sidebar;
+        const sidebarContent = sidebarContainer.querySelector('.sidebar') || sidebarContainer;
+        const existingSuperstring = hasSuperstring(sidebarContainer);
+
+        if (existingSuperstring) {
+            if (sidebarContent.lastElementChild !== existingSuperstring) {
+                sidebarContent.appendChild(existingSuperstring);
+            }
             return;
         }
 
@@ -173,7 +186,7 @@ window.addEventListener("pageshow", () => {
                 bodyContainer.appendChild(actionLinks);
                 superstring.appendChild(bodyContainer);
 
-                sidebar.appendChild(superstring);
+                sidebarContent.appendChild(superstring);
             }
             else {
                 const superstring = document.createElement('div');
@@ -189,7 +202,7 @@ window.addEventListener("pageshow", () => {
                 actionLinks.appendChild(link);
                 superstring.appendChild(actionLinks);
 
-                sidebar.appendChild(superstring);
+                sidebarContent.appendChild(superstring);
             }
         }
     }
@@ -270,7 +283,7 @@ window.addEventListener("pageshow", () => {
 
     const isIntegrationsSection = (el) => el.classList && el.classList.contains('configuration-sync-section');
 
-    const hasSuperstring = el => el.querySelector('.superstring') != null;
+    const hasSuperstring = el => el.querySelector('.superstring');
 
     const nextElementSibling = el => el.nextElementSibling;
 

--- a/src/epoxy.js
+++ b/src/epoxy.js
@@ -150,6 +150,10 @@ window.addEventListener("pageshow", () => {
 
         if (existingSuperstring) {
             if (sidebarContent.lastElementChild !== existingSuperstring) {
+                console.debug('Epoxy: moving Superstring section to end of sidebar.', {
+                    sidebarContent,
+                    existingSuperstring,
+                });
                 sidebarContent.appendChild(existingSuperstring);
             }
             return;
@@ -186,6 +190,10 @@ window.addEventListener("pageshow", () => {
                 bodyContainer.appendChild(actionLinks);
                 superstring.appendChild(bodyContainer);
 
+                console.debug('Epoxy: adding Superstring section to sidebar.', {
+                    sidebarContent,
+                    superstring,
+                });
                 sidebarContent.appendChild(superstring);
             }
             else {
@@ -202,6 +210,10 @@ window.addEventListener("pageshow", () => {
                 actionLinks.appendChild(link);
                 superstring.appendChild(actionLinks);
 
+                console.debug('Epoxy: adding Superstring section to sidebar.', {
+                    sidebarContent,
+                    superstring,
+                });
                 sidebarContent.appendChild(superstring);
             }
         }

--- a/src/epoxy.js
+++ b/src/epoxy.js
@@ -146,11 +146,30 @@ window.addEventListener("pageshow", () => {
             ? sidebar
             : sidebar.closest('.sidebar-container') || sidebar;
         const sidebarContent = sidebarContainer.querySelector('.sidebar') || sidebarContainer;
-        const existingSuperstring = hasSuperstring(sidebarContainer);
+        const superstringSections = sidebarContainer.querySelectorAll('.superstring');
+        const existingSuperstring = superstringSections[superstringSections.length - 1] || null;
+
+        console.log('Epoxy: sidebar mutation detected.', {
+            sidebar,
+            sidebarContainer,
+            sidebarContent,
+            superstringCount: superstringSections.length,
+        });
 
         if (existingSuperstring) {
+            if (superstringSections.length > 1) {
+                console.warn('Epoxy: removing duplicate Superstring sections.', {
+                    superstringCount: superstringSections.length,
+                    sidebarContent,
+                });
+                superstringSections.forEach((section, index) => {
+                    if (index < superstringSections.length - 1) {
+                        section.remove();
+                    }
+                });
+            }
             if (sidebarContent.lastElementChild !== existingSuperstring) {
-                console.debug('Epoxy: moving Superstring section to end of sidebar.', {
+                console.log('Epoxy: moving Superstring section to end of sidebar.', {
                     sidebarContent,
                     existingSuperstring,
                 });
@@ -190,7 +209,7 @@ window.addEventListener("pageshow", () => {
                 bodyContainer.appendChild(actionLinks);
                 superstring.appendChild(bodyContainer);
 
-                console.debug('Epoxy: adding Superstring section to sidebar.', {
+                console.log('Epoxy: adding Superstring section to sidebar.', {
                     sidebarContent,
                     superstring,
                 });
@@ -210,7 +229,7 @@ window.addEventListener("pageshow", () => {
                 actionLinks.appendChild(link);
                 superstring.appendChild(actionLinks);
 
-                console.debug('Epoxy: adding Superstring section to sidebar.', {
+                console.log('Epoxy: adding Superstring section to sidebar.', {
                     sidebarContent,
                     superstring,
                 });


### PR DESCRIPTION
### Motivation
- Reduce continuous DOM updates caused by repeatedly re-appending the Superstring section to the sidebar. 
- Ensure the Superstring section is appended into the correct sidebar content container (`.sidebar` or `.sidebar-container`) so the link remains functional. 
- Allow callers to reuse the located Superstring element by returning the element from `hasSuperstring` instead of a boolean. 

### Description
- In `addSuperstringSidebarSection` compute `sidebarContainer` and `sidebarContent` and append Superstring into `sidebarContent` instead of the original `sidebar` when creating or moving the node. 
- Avoid redundant reattachment by checking `if (sidebarContent.lastElementChild !== existingSuperstring)` before calling `sidebarContent.appendChild(existingSuperstring)`. 
- Change `hasSuperstring` to return the result of `querySelector('.superstring')` (the element) so callers can move it directly, and remove the earlier combined early-return that hid the element. 
- All changes are in `src/epoxy.js` and are limited to DOM-querying and DOM-manipulation logic around the Superstring sidebar section. 

### Testing
- No automated tests were run.
- No test failures reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d4807f3788331b011b917194926c5)